### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,8 +4,8 @@ SkinConductance	KEYWORD1
 setSampleRate	KEYWORD2
 update	KEYWORD2
 reset	KEYWORD2
-Lop KEYWORD2
-Hip KEYWORD2
+Lop	KEYWORD2
+Hip	KEYWORD2
 getNormalized	KEYWORD2
 getRaw	KEYWORD2
 bpmChange	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords